### PR TITLE
Fix so I can work.

### DIFF
--- a/src/absorptionlines.cc
+++ b/src/absorptionlines.cc
@@ -1930,3 +1930,40 @@ String Absorption::Lines::MetaData() const noexcept
   
   return os.str();
 }
+
+
+void Absorption::Lines::RemoveUnusedLocalQuantums()
+{
+  // Find all hits
+  std::vector<size_t> hits(0);
+  
+  //
+  for (size_t i=0; i<mlocalquanta.size(); i++) {
+    bool found=false;
+    for (auto& line: mlines) {
+      if (line.LowerQuantumNumber(i).isDefined() or line.UpperQuantumNumber(i).isDefined()) {
+        found = true;
+      }
+    }
+    
+    if (not found) {
+      hits.push_back(i);
+    }
+  }
+  
+  // Remove from behind to not mess up
+  while (not hits.empty()) {
+    RemoveLocalQuantum(hits.back());
+    hits.pop_back();
+  }
+}
+
+void Absorption::Lines::RemoveLocalQuantum(size_t x)
+{
+  mlocalquanta.erase(mlocalquanta.begin() + x);
+  for (auto& line: mlines) {
+    line.LowerQuantumNumbers().erase(line.LowerQuantumNumbers().begin() + x);
+    line.UpperQuantumNumbers().erase(line.UpperQuantumNumbers().begin() + x);
+  }
+}
+

--- a/src/absorptionlines.h
+++ b/src/absorptionlines.h
@@ -744,6 +744,14 @@ public:
   /** Number of broadening species */
   Index NumBroadeners() const noexcept {return Index(mlocalquanta.size());}
   
+  /** Remove quantum numbers that are not used by even a single line
+   */
+  void RemoveUnusedLocalQuantums();
+  
+  /** Remove quantum numbers at the given position from all lines 
+   */
+  void RemoveLocalQuantum(size_t);
+  
   /** Quantum number lower level
    * 
    * @param[in] k Line number (less than NumLines())

--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -141,3 +141,11 @@ void abs_linesTruncateGlobalQuantumNumbers(ArrayOfAbsorptionLines& abs_lines,
   for (auto& lines: abs_lines)
     lines.sort_by_frequency();
 }
+
+void abs_linesRemoveUnusedLocalQuantumNumbers(ArrayOfAbsorptionLines& abs_lines,
+                                              const Verbosity&)
+{
+  for(auto& lines: abs_lines) {
+    lines.RemoveUnusedLocalQuantums();
+  }
+}

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -668,6 +668,21 @@ void define_md_data_raw() {
       GIN_DESC("Relative change in line strengths.")));
 
   md_data_raw.push_back(MdRecord(
+    NAME("abs_linesRemoveUnusedLocalQuantumNumbers"),
+      DESCRIPTION(
+          "Removes unused quantums from local values in the line lists\n"),
+      AUTHORS("Richard Larsson"),
+      OUT("abs_lines2"),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN("abs_lines2"),
+      GIN(),
+      GIN_TYPE(),
+      GIN_DEFAULT(),
+      GIN_DESC()));
+
+  md_data_raw.push_back(MdRecord(
       NAME("abs_linesReplaceWithLines"),
       DESCRIPTION(
           "Replace all lines in *abs_lines* that match with lines in replacement_lines.\n"


### PR DESCRIPTION
Function handle is abs_linesRemoveUnusedLocalQuantumNumbers.  Reading
and splitting HITRAN with all quantum numbers available will now work.
It splits it to 5300 files.  Still takes less space on the harddrive
because the majority of lines have a width lower than 160 chars