### PR TITLE
Search path and gzip support for ARTSCATs

### DIFF
--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -70,8 +70,9 @@ void ReadArrayOfARTSCAT(ArrayOfAbsorptionLines& abs_lines,
   Index nelem;
   
   // ARTSCAT data
-  ifstream is_xml;
-  xml_open_input_file(is_xml, artscat_file, verbosity);
+  shared_ptr<istream> ifs = nullptr;
+  xml_find_and_open_input_file(ifs, artscat_file, verbosity);
+  istream& is_xml = *ifs;
   auto a = FILE_TYPE_ASCII;
   auto b = NUMERIC_TYPE_DOUBLE;
   auto c = ENDIAN_TYPE_LITTLE;
@@ -202,8 +203,9 @@ void ReadARTSCAT(ArrayOfAbsorptionLines& abs_lines,
   Index nelem;
   
   // ARTSCAT data
-  ifstream is_xml;
-  xml_open_input_file(is_xml, artscat_file, verbosity);
+  shared_ptr<istream> ifs = nullptr;
+  xml_find_and_open_input_file(ifs, artscat_file, verbosity);
+  istream& is_xml = *ifs;
   auto a = FILE_TYPE_ASCII;
   auto b = NUMERIC_TYPE_DOUBLE;
   auto c = ENDIAN_TYPE_LITTLE;

--- a/src/xml_io.cc
+++ b/src/xml_io.cc
@@ -641,6 +641,37 @@ void xml_open_input_file(igzstream& ifs,
 
 #endif /* ENABLE_ZLIB */
 
+void xml_find_and_open_input_file(std::shared_ptr<istream>& ifs,
+                                  const String& filename,
+                                  const Verbosity& verbosity) {
+  CREATE_OUT2;
+
+  String xml_file = filename;
+  find_xml_file(xml_file, verbosity);
+  out2 << "  Reading " << xml_file << '\n';
+
+  // Open input stream:
+  if (xml_file.substr(xml_file.length() - 3, 3) == ".gz")
+#ifdef ENABLE_ZLIB
+  {
+    ifs = std::shared_ptr<istream>(new igzstream());
+    xml_open_input_file(
+        *(std::static_pointer_cast<igzstream>(ifs)), xml_file, verbosity);
+  }
+#else
+  {
+    throw runtime_error(
+        "This arts version was compiled without zlib support.\n"
+        "Thus zipped xml files cannot be read.");
+  }
+#endif /* ENABLE_ZLIB */
+  else {
+    ifs = shared_ptr<istream>(new ifstream());
+    xml_open_input_file(
+        *(std::static_pointer_cast<ifstream>(ifs)), xml_file, verbosity);
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////
 //   General XML functions (file header, start root tag, end root tag)
 ////////////////////////////////////////////////////////////////////////////

--- a/src/xml_io_private.h
+++ b/src/xml_io_private.h
@@ -32,6 +32,7 @@
 #define xml_io_private_h
 
 #include <cfloat>
+#include <memory>
 #include <stdexcept>
 #include "absorption.h"
 #include "agenda_class.h"
@@ -54,6 +55,18 @@ void xml_open_output_file(ostream& file, const String& name);
 void xml_open_input_file(ifstream& file,
                          const String& name,
                          const Verbosity& verbosity);
+
+/** Open plain or zipped xml file.
+ *
+ * Searches the include and data paths for the given filename.
+ *
+ * \param[out] ifs Pointer to input file stream
+ * \param[in]  filename Input filename
+ * \param[in]  verbosity Verbosity
+ */
+void xml_find_and_open_input_file(std::shared_ptr<istream>& ifs,
+                                  const String& filename,
+                                  const Verbosity& verbosity);
 
 ////////////////////////////////////////////////////////////////////////////
 //   XML parser classes


### PR DESCRIPTION
Take search path into account for ReadARTSCAT and ReadArrayOfARTSCAT and
support gzipped catalogs as discussed in atmtools/arts#70