### PR TITLE
Update cmake config for gui build

### DIFF
--- a/3rdparty/gui/CMakeLists.txt
+++ b/3rdparty/gui/CMakeLists.txt
@@ -1,37 +1,14 @@
-cmake_minimum_required(VERSION 3.6)
-
 if (ARTS_GUI)
+  cmake_minimum_required(VERSION 3.10)
   project(imgui_interface)
-  
+
   add_subdirectory(imgui)
   add_subdirectory(implot)
   
-  include_directories(${PROJECT_SOURCE_DIR})
   add_executable(imgui_example imgui_example.cpp)
+  target_include_directories(imgui_example PUBLIC ${PROJECT_SOURCE_DIR})
   target_link_libraries(imgui_example imgui)
 
-  # glfw
-  find_package(glfw3 REQUIRED)
-  include_directories(${GLFW_INCLUDE_DIRS})
-  link_libraries(${GLFW_LIBRARY_DIRS})
-  
-  # opengl
-  set(OpenGL_GL_PREFERENCE GLVND)
-  find_package(OpenGL REQUIRED)
-  include_directories(${OPENGL_INCLUDE_DIRS})
-  
-  # glew
-  find_package(GLEW REQUIRED)
-  include_directories(${GLEW_INCLUDE_DIRS})
-  
-  target_link_libraries(
-        imgui_example
-        glfw
-        ${OPENGL_LIBRARIES}
-        ${GLEW_LIBRARIES}
-        ${EXTRA_LIBS}
-  )
-  
   # Add several errors here
   
   message(STATUS "Added GUI libraries (-DARTS_GUI=0 to deactivate)")

--- a/3rdparty/gui/imgui/CMakeLists.txt
+++ b/3rdparty/gui/imgui/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.6)
+find_package(glfw3 REQUIRED)
+
+find_package(GLEW REQUIRED)
+
+set(OpenGL_GL_PREFERENCE GLVND)
+find_package(OpenGL REQUIRED)
+
 add_library(
         imgui STATIC
             imconfig.h
@@ -16,5 +22,6 @@ add_library(
             imstb_textedit.h
             imstb_truetype.h
         )
-target_include_directories(imgui PUBLIC .)
+target_include_directories(imgui PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(imgui PUBLIC ImDrawIdx=unsigned\ int)
+target_link_libraries(imgui glfw GLEW::glew OpenGL::GL)

--- a/3rdparty/gui/implot/CMakeLists.txt
+++ b/3rdparty/gui/implot/CMakeLists.txt
@@ -1,11 +1,8 @@
-cmake_minimum_required(VERSION 3.6)
 add_library(
         implot STATIC
             implot.cpp
             implot.h
         )
-target_include_directories(implot PUBLIC
-    ../imgui
-    ./
-)
+target_include_directories(implot PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(implot PUBLIC ImDrawIdx=unsigned\ int)
+target_link_libraries(implot imgui)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -540,22 +540,6 @@ arts_test_cmdline("check-docs" -C)
 
 ############# GUI ###############
 if (ARTS_GUI)
-  cmake_minimum_required(VERSION 3.6)
-
-  # glfw
-  find_package(glfw3 REQUIRED)
-  include_directories(${GLFW_INCLUDE_DIRS})
-  link_libraries(${GLFW_LIBRARY_DIRS})
-
-  # opengl
-  set(OpenGL_GL_PREFERENCE GLVND)
-  find_package(OpenGL REQUIRED)
-  include_directories(${OPENGL_INCLUDE_DIRS})
-
-  # glew
-  find_package(GLEW REQUIRED)
-  include_directories(${GLEW_INCLUDE_DIRS})
-  
   add_library(artsgui STATIC
     gui_inc.cc
     gui_help.cc
@@ -567,11 +551,6 @@ if (ARTS_GUI)
   target_link_libraries(artsgui
           imgui
           implot
-          glfw
-          ${OPENGL_LIBRARIES}
-          ${GLEW_LIBRARIES}
-          ${EXTRA_LIBS}
-          matpack
   )
   target_link_libraries(artscore artsgui)
 
@@ -581,5 +560,5 @@ if (ARTS_GUI)
   
   ############## GUI TEST ###################
   add_executable(test_gui test_gui.cc)
-  target_link_libraries(test_gui artscore ${ALL_ARTS_LIBRARIES})
+  target_link_libraries(test_gui ${ALL_ARTS_LIBRARIES})
 endif()

--- a/src/gui_inc.h
+++ b/src/gui_inc.h
@@ -1,10 +1,10 @@
 #ifndef GUI_INC_H
 #define GUI_INC_H
 
-#include "../3rdparty/gui/imgui/imgui.h"
-#include "../3rdparty/gui/imgui/imgui_impl_glfw.h"
-#include "../3rdparty/gui/imgui/imgui_impl_opengl3.h"
-#include "../3rdparty/gui/implot/implot.h"
+#include <imgui.h>
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_opengl3.h>
+#include <implot.h>
 #include <stdio.h>
 
 #include <GL/glew.h>     // Initialize with glewInit()


### PR DESCRIPTION
Avoid duplicate find_package commands for the same libraries.
Dependencies are now detected and provided by the imgui target.

Increase cmake requirement to 3.10. Needed for OpenGL_GL_PREFERENCE and
OpenGL imported target feature.

Remove relative include paths for imgui in gui_inc.h. Location of the
imgui includes is provided and added to the include path  by the imgui target.

Build works now if dependencies are not installed in default /usr
location. Also fixes build on macOS.