### PR TITLE
Partially revert 5f5dbf3

### DIFF
--- a/src/m_rte.cc
+++ b/src/m_rte.cc
@@ -772,17 +772,16 @@ void iyEmissionStandard(
     const bool temperature_jacobian =
         j_analytical_do and do_temperature_jacobian(jacobian_quantities);
 
+    Agenda l_propmat_clearsky_agenda(propmat_clearsky_agenda);
+    Workspace l_ws(ws);
     ArrayOfString fail_msg;
     bool do_abort = false;
 
     // Loop ppath points and determine radiative properties
 #pragma omp parallel for if (!arts_omp_in_parallel()) \
-    firstprivate(a, B, dB_dT, S, da_dx, dS_dx) schedule(guided)
+    firstprivate(l_ws, l_propmat_clearsky_agenda, a, B, dB_dT, S, da_dx, dS_dx) \
+    schedule(guided)
     for (Index ip = 0; ip < np; ip++) {
-      
-      thread_local Workspace l_ws(ws);
-      thread_local Agenda l_propmat_clearsky_agenda(propmat_clearsky_agenda);
-      
       if (do_abort) continue;
       try {
         get_stepwise_blackbody_radiation(


### PR DESCRIPTION
Use firstprivate again instead of thread_local to fix failing test.

I think you cannot replace the firstprivate variables with thread_local variables. The problem is that the variable is not properly initialised when the function is called a second time. Initialization happens only once per thread. If the same thread is reused (which it is with OpenMP), the thread_local variable will not be reinitialised when the function is called a second time.

Check out this short example:

```cpp
#include <iostream>

void do_something()
{
  for (int j=1; j<5; j++)
    {
      thread_local int i = 0;
      i++;
      std::cout << i << std::endl;
    }
}

int main()
{
  do_something();
  std::cout << std::endl;
  do_something();
  return 0;
}
```

You might expect that the output for both calls of do_something is the same. The output of i always running from 1 to 4. But it is not, the second call outputs 5 to 8 because i is still in the same thread and thus not initialized again. OpenMPs firstprivate directive however ensures that all threadprivate variables are properly initialised once at the beginning of the loop.

thread_local variables behave just like static variables in this case.

In our case we need to reinitialise l_ws and the l_propmat_clearsky_agenda on every call of the function.
