### PR TITLE
Fix WSM input variables

### DIFF
--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -196,7 +196,7 @@ std::vector<Method> methods() {
     inoutvarpos.push_back({x.InOut().cbegin(), x.InOut().cend()});
   std::vector<std::vector<std::size_t>> invarpos;
   for (auto& x : global_data::md_data)
-    invarpos.push_back({x.In().cbegin(), x.In().cend()});
+    invarpos.push_back({x.InOnly().cbegin(), x.InOnly().cend()});
   std::vector<std::vector<std::size_t>> outvarpos;
   for (auto& x : global_data::md_data)
     outvarpos.push_back({x.Out().cbegin(), x.Out().cend()});

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -849,7 +849,7 @@ int main() {
     "  Var::verbosity(ws).set_main_agenda(1);\n"
     "\n"
     "  #ifndef NDEBUG\n"
-    "  ws.context = "";\n"
+    "  ws.context = \"\";\n"
   "  #endif\n"
   "\n"
   "  return ws;"


### PR DESCRIPTION
The list of inputs used for generating the getaway call to WSMs should
only contain WSVs that are solely input. If they're also defined as
output, they have to be omitted.